### PR TITLE
Fetch shipping labels in bulk via GraphQL

### DIFF
--- a/shopify_reports.py
+++ b/shopify_reports.py
@@ -78,16 +78,85 @@ def fetch_all_products() -> dict:
     return products
 
 
-def fetch_shipping_labels(order_id: int) -> list[dict]:
-    """Retrieve shipping labels purchased for the given order."""
-    endpoint = f"orders/{order_id}/shipping_labels.json"
+def fetch_all_shipping_labels() -> dict[int, list[dict]]:
+    """Retrieve shipping label information for all orders using GraphQL pages."""
+
+    url = build_shopify_url("graphql.json")
     headers = get_shopify_headers()
-    url = build_shopify_url(endpoint)
-    response = requests.get(url, headers=headers)
-    if response.status_code == 404:
-        return []
-    response.raise_for_status()
-    return response.json().get("shipping_labels", [])
+
+    query = """
+    query ($cursor: String) {
+      orders(first: 50, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            id
+            fulfillments {
+              shippingLabel {
+                shippingCost {
+                  amount
+                  currencyCode
+                }
+                carrier
+                service
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    labels_map: dict[int, list[dict]] = {}
+    cursor = None
+
+    while True:
+        variables = {"cursor": cursor}
+        response = requests.post(
+            url, headers=headers, json={"query": query, "variables": variables}
+        )
+        response.raise_for_status()
+
+        orders_data = response.json().get("data", {}).get("orders", {})
+        for edge in orders_data.get("edges", []):
+            node = edge.get("node", {})
+            order_gid = node.get("id")
+            if not order_gid:
+                continue
+            try:
+                order_id = int(order_gid.split("/")[-1])
+            except (TypeError, ValueError):
+                continue
+
+            for fulfillment in node.get("fulfillments", []):
+                label = fulfillment.get("shippingLabel")
+                if not label:
+                    continue
+                cost = label.get("shippingCost", {})
+                amount = cost.get("amount")
+                try:
+                    amount_val = float(amount) if amount is not None else 0.0
+                except (TypeError, ValueError):
+                    amount_val = 0.0
+
+                labels_map.setdefault(order_id, []).append(
+                    {
+                        "price": amount_val,
+                        "currencyCode": cost.get("currencyCode"),
+                        "carrier": label.get("carrier"),
+                        "service": label.get("service"),
+                    }
+                )
+
+        page_info = orders_data.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+
+    return labels_map
 
 
 def collect_metrics(orders: list[dict], products: dict) -> dict:
@@ -96,6 +165,8 @@ def collect_metrics(orders: list[dict], products: dict) -> dict:
     free_shipping_cost = 0.0
     product_revenue = defaultdict(float)
     order_shipping_rows = []
+
+    labels_map = fetch_all_shipping_labels()
 
     for order in orders:
         created = order.get("created_at")
@@ -106,7 +177,7 @@ def collect_metrics(orders: list[dict], products: dict) -> dict:
             price = float(sl.get("price", 0.0))
             total_paid_shipping += price
 
-        labels = fetch_shipping_labels(order_id)
+        labels = labels_map.get(order_id, [])
         total_label_cost = 0.0
         label_details = []
         for lbl in labels:


### PR DESCRIPTION
## Summary
- pull shipping labels for all orders with a single paginated GraphQL query
- store the labels in a map for use while collecting metrics

## Testing
- `python -m py_compile shopify_reports.py`


------
https://chatgpt.com/codex/tasks/task_e_687e6e65a9cc8332950d9ac6cc4fa541