### PR TITLE
Add initial Flask webapp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask
+Flask-SQLAlchemy
+Flask-Login
+Flask-WTF
+Flask-Bcrypt
+Flask-Migrate
+Flask-Admin

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from webapp import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,0 +1,48 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+from flask_bcrypt import Bcrypt
+from flask_migrate import Migrate
+
+# Initialize extensions
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+bcrypt = Bcrypt()
+migrate = Migrate()
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SECRET_KEY'] = 'changeme'
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+    db.init_app(app)
+    login_manager.init_app(app)
+    bcrypt.init_app(app)
+    migrate.init_app(app, db)
+
+    from .models import User
+    login_manager.login_view = 'auth.login'
+
+    from .views.auth import auth_bp
+    from .views.main import main_bp
+    from .views.green import green_bp
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(main_bp)
+    app.register_blueprint(green_bp)
+
+    # Flask-Admin setup
+    from flask_admin import Admin
+    from flask_admin.contrib.sqla import ModelView
+    admin = Admin(app, name='Ceto Admin', template_mode='bootstrap4')
+    from .models import GreenData, TastingNote, Suggestion, SuggestionVote
+    admin.add_view(ModelView(User, db.session))
+    admin.add_view(ModelView(GreenData, db.session))
+    admin.add_view(ModelView(TastingNote, db.session))
+    admin.add_view(ModelView(Suggestion, db.session))
+    admin.add_view(ModelView(SuggestionVote, db.session))
+
+    return app

--- a/webapp/forms.py
+++ b/webapp/forms.py
@@ -1,0 +1,26 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, BooleanField, TextAreaField, FileField
+from wtforms.validators import DataRequired, Email, EqualTo, Length
+
+
+class RegistrationForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired(), Length(max=80)])
+    email = StringField('Email', validators=[DataRequired(), Email(), Length(max=120)])
+    password = PasswordField('Password', validators=[DataRequired()])
+    password2 = PasswordField('Confirm Password',
+                              validators=[DataRequired(), EqualTo('password')])
+
+
+class LoginForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired()])
+    password = PasswordField('Password', validators=[DataRequired()])
+    remember_me = BooleanField('Remember Me')
+
+
+class GreenUploadForm(FlaskForm):
+    file = FileField('Green File (PDF/Excel)')
+    manual_data = TextAreaField('Manual Entry')
+
+
+class TastingNoteForm(FlaskForm):
+    notes = TextAreaField('Tasting Notes', validators=[DataRequired()])

--- a/webapp/models/__init__.py
+++ b/webapp/models/__init__.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from flask_login import UserMixin
+from .. import db, login_manager, bcrypt
+
+
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    karma = db.Column(db.Integer, default=0)
+    registered_on = db.Column(db.DateTime, default=datetime.utcnow)
+
+    greens = db.relationship('GreenData', backref='uploader', lazy=True)
+    notes = db.relationship('TastingNote', backref='author', lazy=True)
+    suggestions = db.relationship('Suggestion', backref='author', lazy=True)
+
+    def set_password(self, password: str):
+        self.password_hash = bcrypt.generate_password_hash(password).decode('utf-8')
+
+    def check_password(self, password: str) -> bool:
+        return bcrypt.check_password_hash(self.password_hash, password)
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+
+class GreenData(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    filename = db.Column(db.String(200))
+    manual_data = db.Column(db.Text)
+    uploaded_by = db.Column(db.Integer, db.ForeignKey('user.id'))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    notes = db.relationship('TastingNote', backref='green', lazy=True)
+    suggestions = db.relationship('Suggestion', backref='green', lazy=True)
+
+
+class TastingNote(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    green_data_id = db.Column(db.Integer, db.ForeignKey('green_data.id'))
+    notes = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class Suggestion(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    green_data_id = db.Column(db.Integer, db.ForeignKey('green_data.id'), nullable=True)
+    suggestion_text = db.Column(db.Text, nullable=False)
+    accepted = db.Column(db.Boolean, default=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    accepted_at = db.Column(db.DateTime)
+
+    votes = db.relationship('SuggestionVote', backref='suggestion', lazy=True)
+
+
+class SuggestionVote(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    suggestion_id = db.Column(db.Integer, db.ForeignKey('suggestion.id'))
+    vote = db.Column(db.Integer, default=1)  # +1 or -1
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Ceto</title>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('main.index') }}">Ceto</a>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('green.upload_green') }}">Upload Green</a>
+        </li>
+      </ul>
+      <ul class="navbar-nav">
+        {% if current_user.is_authenticated %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>
+        </li>
+        {% else %}
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Login</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container mt-4">
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    {% for category, message in messages %}
+      <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+    {% endfor %}
+  {% endif %}
+{% endwith %}
+{% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/webapp/templates/green_detail.html
+++ b/webapp/templates/green_detail.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Green Data {{ green.id }}</h2>
+<p>Filename: {{ green.filename or 'Manual Entry' }}</p>
+<p>Uploaded by: {{ green.uploader.username }}</p>
+{% if green.manual_data %}
+<pre>{{ green.manual_data }}</pre>
+{% endif %}
+
+<h3>Tasting Notes</h3>
+<ul>
+{% for note in green.notes %}
+  <li>{{ note.author.username }}: {{ note.notes }}</li>
+{% endfor %}
+</ul>
+
+<form method="POST">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.notes.label(class="form-label") }}
+    {{ form.notes(class="form-control", rows=4) }}
+  </div>
+  <button type="submit" class="btn btn-primary">Add Note</button>
+</form>
+{% endblock %}

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Green Data</h1>
+<table class="table">
+  <thead><tr><th>ID</th><th>Filename</th><th>Uploader</th><th>Date</th></tr></thead>
+  <tbody>
+  {% for g in greens %}
+  <tr>
+    <td><a href="{{ url_for('green.green_detail', green_id=g.id) }}">{{ g.id }}</a></td>
+    <td>{{ g.filename or 'Manual Entry' }}</td>
+    <td>{{ g.uploader.username }}</td>
+    <td>{{ g.created_at.strftime('%Y-%m-%d') }}</td>
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/webapp/templates/login.html
+++ b/webapp/templates/login.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="POST" action="">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.username.label(class="form-label") }}
+    {{ form.username(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.password.label(class="form-label") }}
+    {{ form.password(class="form-control") }}
+  </div>
+  <div class="form-check mb-3">
+    {{ form.remember_me(class="form-check-input") }}
+    {{ form.remember_me.label(class="form-check-label") }}
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}

--- a/webapp/templates/register.html
+++ b/webapp/templates/register.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Register</h2>
+<form method="POST" action="">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.username.label(class="form-label") }}
+    {{ form.username(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.email.label(class="form-label") }}
+    {{ form.email(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.password.label(class="form-label") }}
+    {{ form.password(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.password2.label(class="form-label") }}
+    {{ form.password2(class="form-control") }}
+  </div>
+  <button type="submit" class="btn btn-primary">Register</button>
+</form>
+{% endblock %}

--- a/webapp/templates/upload.html
+++ b/webapp/templates/upload.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Upload Green Data</h2>
+<form method="POST" enctype="multipart/form-data">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.file.label(class="form-label") }}
+    {{ form.file(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.manual_data.label(class="form-label") }}
+    {{ form.manual_data(class="form-control", rows=5) }}
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+{% endblock %}

--- a/webapp/views/auth.py
+++ b/webapp/views/auth.py
@@ -1,0 +1,42 @@
+from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask_login import login_user, logout_user, login_required
+
+from .. import db
+from ..models import User
+from ..forms import RegistrationForm, LoginForm
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@auth_bp.route('/register', methods=['GET', 'POST'])
+def register():
+    form = RegistrationForm()
+    if form.validate_on_submit():
+        user = User(username=form.username.data, email=form.email.data)
+        user.set_password(form.password.data)
+        db.session.add(user)
+        db.session.commit()
+        flash('Registration successful. You can now log in.', 'success')
+        return redirect(url_for('auth.login'))
+    return render_template('register.html', form=form)
+
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = User.query.filter_by(username=form.username.data).first()
+        if user and user.check_password(form.password.data):
+            login_user(user, remember=form.remember_me.data)
+            return redirect(url_for('main.index'))
+        else:
+            flash('Invalid username or password', 'danger')
+    return render_template('login.html', form=form)
+
+
+@auth_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    flash('You have been logged out.', 'info')
+    return redirect(url_for('auth.login'))

--- a/webapp/views/green.py
+++ b/webapp/views/green.py
@@ -1,0 +1,53 @@
+from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask_login import login_required, current_user
+from werkzeug.utils import secure_filename
+import os
+
+from .. import db
+from ..models import GreenData, TastingNote
+from ..forms import GreenUploadForm, TastingNoteForm
+
+
+green_bp = Blueprint('green', __name__, url_prefix='/green')
+UPLOAD_FOLDER = 'uploads'
+
+
+def ensure_upload_folder():
+    os.makedirs(os.path.join(os.getcwd(), UPLOAD_FOLDER), exist_ok=True)
+
+
+@green_bp.route('/upload', methods=['GET', 'POST'])
+@login_required
+def upload_green():
+    form = GreenUploadForm()
+    ensure_upload_folder()
+    if form.validate_on_submit():
+        filename = None
+        if form.file.data:
+            filename = secure_filename(form.file.data.filename)
+            save_path = os.path.join(UPLOAD_FOLDER, filename)
+            form.file.data.save(save_path)
+        green = GreenData(filename=filename,
+                          manual_data=form.manual_data.data,
+                          uploader=current_user)
+        db.session.add(green)
+        db.session.commit()
+        flash('Green data uploaded.', 'success')
+        return redirect(url_for('main.index'))
+    return render_template('upload.html', form=form)
+
+
+@green_bp.route('/<int:green_id>', methods=['GET', 'POST'])
+@login_required
+def green_detail(green_id):
+    green = GreenData.query.get_or_404(green_id)
+    form = TastingNoteForm()
+    if form.validate_on_submit():
+        note = TastingNote(user_id=current_user.id,
+                           green_data_id=green.id,
+                           notes=form.notes.data)
+        db.session.add(note)
+        db.session.commit()
+        flash('Tasting note added.', 'success')
+        return redirect(url_for('green.green_detail', green_id=green.id))
+    return render_template('green_detail.html', green=green, form=form)

--- a/webapp/views/main.py
+++ b/webapp/views/main.py
@@ -1,0 +1,13 @@
+from flask import Blueprint, render_template
+from flask_login import login_required
+
+from ..models import GreenData
+
+main_bp = Blueprint('main', __name__)
+
+
+@main_bp.route('/')
+@login_required
+def index():
+    greens = GreenData.query.order_by(GreenData.created_at.desc()).all()
+    return render_template('index.html', greens=greens)


### PR DESCRIPTION
## Summary
- add Flask app skeleton with SQLAlchemy models
- include auth blueprint with login and registration
- create green data and tasting note views
- wire up Bootstrap templates
- add requirements file and run script

## Testing
- `python -m py_compile webapp/**/*.py`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688bf889ef888332826008e6a503ef51